### PR TITLE
Adding basic spot to throw lambda slash command files and a couple ex…

### DIFF
--- a/src/lamda_slash_examples/fah.py
+++ b/src/lamda_slash_examples/fah.py
@@ -1,0 +1,52 @@
+import os
+import json
+import urllib.request
+
+from base64 import b64decode
+from urllib.parse import urlparse
+#different lib since aws lambda env butchered this... and my brain
+
+EXPECTED_TOKEN = os.environ['VERIFICATION_TOKEN']
+
+def respond(err, res=None):
+    return {
+        'statusCode': '400' if err else '200',
+        'headers': {
+            'Content-Type': 'application/json',
+        },
+        'body': err.message if err else json.dumps({
+            'text': res,
+            'response_type': 'in_channel'
+        })
+    }
+
+
+def lambda_handler(event, context):
+    
+    params = urllib.parse.parse_qs(b64decode(event['body']))
+    
+    token = params[b'token'][0].decode("utf-8")
+    
+    if token != EXPECTED_TOKEN:
+        return respond(Exception('Invalid request token'))
+        
+    count = -1
+    output = ""
+    
+    url = "https://apps.foldingathome.org/daily_team_summary.txt"
+
+    file = urllib.request.urlopen(url)
+
+    for line in file:
+        decoded_line = line.decode("utf-8")
+        if "CodeDevils" in decoded_line:
+            output = decoded_line
+            break
+        count += 1
+        
+    if not output:
+        return respond(None, "CodeDevils not found!")
+    
+    data = output.split('\t', 3)
+
+    return respond(None, f"The CodeDevils are currently ranked #{count:,} with {int(data[2]):,} points amassed!\nFor a full breakdown of our team go to https://stats.foldingathome.org/team/249718!")

--- a/src/lamda_slash_examples/roll.py
+++ b/src/lamda_slash_examples/roll.py
@@ -1,0 +1,53 @@
+import json
+import os
+import random
+import time
+
+from base64 import b64decode
+from urlparse import parse_qs
+#different lib since aws lambda env butchered this... and my brain
+
+EXPECTED_TOKEN = os.environ['VERIFICATION_TOKEN']
+
+
+def respond(err, res=None):
+    return {
+        'statusCode': '400' if err else '200',
+        'headers': {
+            'Content-Type': 'application/json',
+        },
+        'body': err.message if err else json.dumps({
+            'text': res,
+            'response_type': 'in_channel'
+        })
+    }
+
+
+def lambda_handler(event, context):
+    
+    random.seed(time.time())
+    
+    params = parse_qs(b64decode(event['body']))
+    
+    token = params['token'][0]
+    user = params['user_name'][0]
+    output = 0
+    
+    if token != EXPECTED_TOKEN:
+        return respond(Exception('Invalid request token'))
+
+    if 'text' in params:
+        number = params['text'][0]
+        stripped = number.split(' ', 1)
+
+        try:
+            tmp = int(stripped[0])
+        except:
+            return respond(None, "A %s is not an integer... %s" % (stripped[0], user))
+        
+        output = random.randint(0,tmp)
+
+    else:
+        output = random.randint(0,100)
+
+    return respond(None, "%s rolled a %d" % (user, output))


### PR DESCRIPTION
roll.py is using the AWS lambda Python 2.7 env... which has urlparse libs and kinda where I started.

fah.py is using the AWS lambda Python 3.7 env... which doesn't and using substituting with the  urllib.parse library results in me getting everything in a dict with byte objects for keys... didn't really look into it too much since was more messing with the aws lambda stuff and figure python will come back on it own... lol